### PR TITLE
Close #28 - Add CLI argument models and parsers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / developers := List(
     "Kevin Lee",
     "kevin.code@kevinlee.io",
     url(s"https://github.com/${props.GitHubUsername}"),
-  )
+  ),
 )
 ThisBuild / homepage := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
 ThisBuild / scmInfo :=
@@ -15,19 +15,44 @@ ThisBuild / scmInfo :=
     url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}"),
     s"https://github.com/${props.GitHubUsername}/${props.RepoName}.git",
   ).some
+ThisBuild / licenses := List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 lazy val whatsub = (project in file("."))
   .settings(
-    name := props.ProjectName
+    name := props.ProjectName,
   )
   .settings(noPublish)
-  .aggregate(core)
+  .aggregate(core, cli)
 
 lazy val core = subProject("core", file("core"))
+  .enablePlugins(BuildInfoPlugin)
   .settings(
     libraryDependencies ++=
       libs.catsAndCatsEffect3 ++ List(libs.catsParse),
+    /* Build Info { */
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoObject := "WhatsubBuildInfo",
+    buildInfoPackage := "whatsub.info",
+    buildInfoOptions += BuildInfoOption.ToJson,
+    /* } Build Info */
   )
+
+lazy val pirate = ProjectRef(props.pirateUri, "pirate")
+
+lazy val cli = subProject("cli", file("cli"))
+  .enablePlugins(NativeImagePlugin)
+  .settings(
+    nativeImageOptions ++= Seq(
+      "--verbose",
+      "--no-fallback",
+      "-H:+ReportExceptionStackTraces",
+      "--initialize-at-build-time",
+      //      s"-H:ReflectionConfigurationFiles=${ (sourceDirectory.value / "graal" / "reflect-config.json").getCanonicalPath }",
+      //      "--allow-incomplete-classpath",
+      //      "--report-unsupported-elements-at-runtime",
+    ),
+  )
+  .dependsOn(core, pirate)
 
 lazy val props =
   new {
@@ -45,6 +70,9 @@ lazy val props =
     final val CatsEffect3Version = "3.1.1"
 
     final val CatsParseVersion = "0.3.4"
+
+    final val pirateVersion = "main"
+    final val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$pirateVersion")
 
     final val IncludeTest: String = "compile->compile;test->test"
   }
@@ -76,4 +104,5 @@ def subProject(projectName: String, file: File): Project =
       name := prefixedProjectName(projectName),
       libraryDependencies ++= libs.hedgehogLibs,
       testFrameworks ~= (testFws => (TestFramework("hedgehog.sbt.Framework") +: testFws).distinct),
+      licenses := List("MIT" -> url("http://opensource.org/licenses/MIT")),
     )

--- a/cli/src/main/scala/whatsub/WhatsubArgs.scala
+++ b/cli/src/main/scala/whatsub/WhatsubArgs.scala
@@ -1,0 +1,94 @@
+package whatsub
+
+import WhatsubArgs.*
+import cats.syntax.option.*
+import pirate.Read
+
+import java.io.File
+
+enum WhatsubArgs derives CanEqual {
+  case ConvertArgs(
+    from: ConvertArgs.From,
+    to: ConvertArgs.To,
+    src: ConvertArgs.SrcFile,
+    out: Option[ConvertArgs.OutFile],
+  )
+}
+object WhatsubArgs {
+
+  def supportedSubFromString(supportedSub: String): Option[SupportedSub] = supportedSub match {
+    case "smi" | "SMI" => SupportedSub.Smi.some
+    case "srt" | "SRT" => SupportedSub.Srt.some
+    case _             => none[SupportedSub]
+  }
+
+  object ConvertArgs {
+    opaque type From = SupportedSub
+    object From {
+      def apply(from: SupportedSub): From = from
+
+      def unapply(from: From): Some[SupportedSub] = Some(from.from)
+
+      given fromCanEqual: CanEqual[From, From] = CanEqual.derived
+
+      implicit final val fromRead: Read[From] = Read.eitherRead { supportedSub =>
+        import scalaz.*
+        import Scalaz.*
+        supportedSubFromString(supportedSub)
+          .map(From(_))
+          .toRightDisjunction("Unknown subtitle type for 'from'. 'from' should be either smi or srt")
+      }
+
+      extension (from0: From) {
+        def from: SupportedSub = from0
+      }
+    }
+
+    opaque type To = SupportedSub
+    object To {
+      def apply(to: SupportedSub): To = to
+
+      def unapply(to: To): Some[SupportedSub] = Some(to.to)
+
+      given toCanEqual: CanEqual[To, To] = CanEqual.derived
+
+      implicit final val toRead: Read[To] = Read.eitherRead { supportedSub =>
+        import scalaz.*
+        import Scalaz.*
+        supportedSubFromString(supportedSub)
+          .map(To(_))
+          .toRightDisjunction("Unknown subtitle type for 'to'. 'to' should be either smi or srt")
+      }
+
+      extension (to0: To) {
+        def to: SupportedSub = to0
+      }
+    }
+
+    opaque type SrcFile = File
+    object SrcFile {
+      def apply(srcFile: File): SrcFile = srcFile
+
+      given srcFileCanEqual: CanEqual[SrcFile, SrcFile] = CanEqual.derived
+
+      extension (srcFile0: SrcFile) {
+        def srcFile: File = srcFile0
+      }
+
+    }
+
+    opaque type OutFile = File
+    object OutFile {
+      def apply(outFile: File): OutFile = outFile
+
+      given outFileCanEqual: CanEqual[OutFile, OutFile] = CanEqual.derived
+
+      extension (outFile0: OutFile) {
+        def outFile: File = outFile0
+      }
+
+    }
+
+  }
+
+}

--- a/cli/src/main/scala/whatsub/WhatsubArgsParser.scala
+++ b/cli/src/main/scala/whatsub/WhatsubArgsParser.scala
@@ -1,0 +1,57 @@
+package whatsub
+
+import scalaz.*
+import Scalaz.*
+import pirate.{ParseError, *}
+import Pirate.*
+import WhatsubArgs.*
+import pirate.internal.ParseTraversal
+import whatsub.info.WhatsubBuildInfo
+
+import java.io.File
+
+/** @author Kevin Lee
+  * @since 2021-07-01
+  */
+object WhatsubArgsParser {
+
+  def fromParse: Parse[ConvertArgs.From] = flag[ConvertArgs.From](
+    both('f', "from"),
+    metavar("<from>") |+| description("A type of subtitle to be converted from"),
+  )
+
+  def toParse: Parse[ConvertArgs.To] = flag[ConvertArgs.To](
+    both('t', "to"),
+    metavar("<to>") |+| description("A type of subtitle to be converted to"),
+  )
+
+  def srcFileParse: Parse[ConvertArgs.SrcFile] = flag[File](
+    both('s', "src"),
+    metavar("<src>") |+| description("The source subtitle file"),
+  ).map(ConvertArgs.SrcFile(_))
+
+  def outFileParse: Parse[Option[ConvertArgs.OutFile]] = flag[File](
+    both('o', "out"),
+    metavar("<out>") |+| description("An optional output subtitle file. If missing, the result is printed out."),
+  ).option.map(_.map(ConvertArgs.OutFile(_)))
+
+  def convertParse: Parse[WhatsubArgs] = WhatsubArgs.ConvertArgs.apply |*| (
+    fromParse,
+    toParse,
+    srcFileParse,
+    outFileParse,
+  )
+
+  val rawCmd: Command[WhatsubArgs] =
+    Command(
+      "Whatsub",
+      "A tool to convert subtitles and re-sync".some,
+      (subcommand(
+        Command(
+          "convert",
+          "Convert subtitles".some,
+          convertParse,
+        ),
+      )) <* version(WhatsubBuildInfo.version),
+    )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
 logLevel := sbt.Level.Warn
 
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.1")
+addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"    % "0.10.0")
+
 val sbtDevOopsVersion = "2.6.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)


### PR DESCRIPTION
Close #28 - Add CLI argument models and parsers
- Add CLI args for sub conversion
- Add parsers for the CLI args
- Add pirate