### PR TITLE
Close #47 - Fix GraalVM build on Windows

### DIFF
--- a/.github/workflows/build-graal.yml
+++ b/.github/workflows/build-graal.yml
@@ -62,51 +62,51 @@ jobs:
           sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} --help"
           sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} convert --help"
 
-#  graalvm_build_windows:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        os: [windows-latest]
-#        run-binary: [whatsub-cli]
-#    steps:
-#      - name: Configure git
-#        run: "git config --global core.autocrlf false"
-#        shell: bash
-#      - uses: actions/checkout@v2.3.4
-#      - uses: olafurpg/setup-scala@v10
-#        with:
-#          java-version: ${{ env.GRAALVM_JAVA_VERSION }}
-#      - uses: ilammy/msvc-dev-cmd@v1
-#      - name: Cache SBT
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            ~/.ivy2/cache
-#            ~/.cache/coursier
-#            ~/.sbt
-#          key: ${{ runner.os }}-sbt-${{ env.CLI_SCALA_BINARY_VERSION }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-#          restore-keys: |
-#            ${{ runner.os }}-sbt-${{ env.CLI_SCALA_BINARY_VERSION }}-
-#
-#      - name: "GraalVM Build for Scala ${{ env.CLI_SCALA_VERSION }} - ${{ github.run_number }}"
-#        shell: bash
-#        env:
-#          CURRENT_BRANCH_NAME: ${{ github.ref }}
-#          RUN_ID: ${{ github.run_id }}
-#          RUN_NUMBER: ${{ github.run_number }}
-#        run: |
-#          sbt \
-#            -J-XX:MaxMetaspaceSize=1024m \
-#            -J-Xmx2048m \
-#            ++${{ env.CLI_SCALA_VERSION }}! \
-#            clean \
-#            test \
-#            nativeImage
-#
-#          rm -f */target/scala-*/*.jar
-#
-#          ls -lGh cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/
-#
-#          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} --version"
-#          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} --help"
-#          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} convert --help"
+  graalvm_build_windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        run-binary: [whatsub-cli]
+    steps:
+      - name: Configure git
+        run: "git config --global core.autocrlf false"
+        shell: bash
+      - uses: actions/checkout@v2.3.4
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ env.GRAALVM_JAVA_VERSION }}
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.cache/coursier
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ env.CLI_SCALA_BINARY_VERSION }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-${{ env.CLI_SCALA_BINARY_VERSION }}-
+
+      - name: "GraalVM Build for Scala ${{ env.CLI_SCALA_VERSION }} - ${{ github.run_number }}"
+        shell: bash
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          sbt \
+            -J-XX:MaxMetaspaceSize=1024m \
+            -J-Xmx2048m \
+            ++${{ env.CLI_SCALA_VERSION }}! \
+            clean \
+            test \
+            nativeImage
+
+          rm -f */target/scala-*/*.jar
+
+          ls -lGh cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/
+
+          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} --version"
+          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} --help"
+          sh -c "cli/target/${{ env.GRAALVM_BIN_DIR_NAME }}/${{ matrix.run-binary }} convert --help"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.1")
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.0")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"    % "0.10.0")
 
 val sbtDevOopsVersion = "2.6.0"


### PR DESCRIPTION
Close #47 - Fix GraalVM build on Windows
- by downgrading `sbt-native-image` from `0.3.1` to `0.3.0`