### PR TITLE
Whatsub v0.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := props.ScalaVersion
-ThisBuild / version := props.ProjectVersion
+ThisBuild / version      := props.ProjectVersion
 ThisBuild / organization := props.Org
-ThisBuild / developers := List(
+ThisBuild / developers   := List(
   Developer(
     props.GitHubUsername,
     "Kevin Lee",
@@ -9,13 +9,13 @@ ThisBuild / developers := List(
     url(s"https://github.com/${props.GitHubUsername}"),
   ),
 )
-ThisBuild / homepage := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
-ThisBuild / scmInfo :=
+ThisBuild / homepage     := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
+ThisBuild / scmInfo      :=
   ScmInfo(
     url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}"),
     s"https://github.com/${props.GitHubUsername}/${props.RepoName}.git",
   ).some
-ThisBuild / licenses := List("MIT" -> url("http://opensource.org/licenses/MIT"))
+ThisBuild / licenses     := List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 lazy val whatsub = (project in file("."))
   .settings(
@@ -31,8 +31,8 @@ lazy val core = subProject("core", file("core"))
     libraryDependencies ++=
       libs.catsAndCatsEffect3 ++ List(libs.catsParse, libs.effectieCatsEffect3) ++ List(libs.extrasCats),
     /* Build Info { */
-    buildInfoKeys := List[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoObject := "WhatsubBuildInfo",
+    buildInfoKeys    := List[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoObject  := "WhatsubBuildInfo",
     buildInfoPackage := "whatsub.info",
     buildInfoOptions += BuildInfoOption.ToJson,
     /* } Build Info */
@@ -43,11 +43,10 @@ lazy val pirate = ProjectRef(props.pirateUri, "pirate")
 lazy val cli = subProject("cli", file("cli"))
   .enablePlugins(JavaAppPackaging, NativeImagePlugin)
   .settings(
-    maintainer := "Kevin Lee <kevin.code@kevinlee.io>",
-    packageSummary := "Whatsub - subtitle converter and syncer",
-    packageDescription := "A tool to convert and sync subtitles",
+    maintainer           := "Kevin Lee <kevin.code@kevinlee.io>",
+    packageSummary       := "Whatsub - subtitle converter and syncer",
+    packageDescription   := "A tool to convert and sync subtitles",
     executableScriptName := props.ExecutableScriptName,
-
     nativeImageOptions ++= List(
       "--verbose",
       "--no-fallback",
@@ -69,7 +68,7 @@ lazy val props =
     final val GitHubUsername = "Kevin-Lee"
     final val RepoName       = "whatsub"
     final val ProjectName    = RepoName
-    final val ProjectVersion = "0.1.0-SNAPSHOT"
+    final val ProjectVersion = "0.1.0"
 
     final val ExecutableScriptName = RepoName
 
@@ -123,9 +122,9 @@ def prefixedProjectName(name: String): String = s"${props.RepoName}${if (name.is
 def subProject(projectName: String, file: File): Project =
   Project(projectName, file)
     .settings(
-      name := prefixedProjectName(projectName),
+      name                       := prefixedProjectName(projectName),
       useAggressiveScalacOptions := true,
       libraryDependencies ++= libs.hedgehogLibs ++ List(libs.canEqual),
       testFrameworks ~= (testFws => (TestFramework("hedgehog.sbt.Framework") +: testFws).distinct),
-      licenses := List("MIT" -> url("http://opensource.org/licenses/MIT")),
+      licenses                   := List("MIT" -> url("http://opensource.org/licenses/MIT")),
     )

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,32 @@
+## [0.1.0](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-08-29
+
+## Done
+* Add `Smi` and `Srt` data models (#7)
+* Add a function to render `Srt` to build an srt subtitle file (#9)
+* Add smi file parser (#11)
+* Add `Converter` to convert `Smi` to `Srt` (#13)
+* Add `SrtParser` (#18)
+* `Convert` from `Srt` to `Smi` (#20)
+* Add render `Smi` (#22)
+* Add error handling to `SmiParser` (#24)
+* Add CLI argument models and parsers (#28)
+* Add CLI to convert subtitles (#30)
+* Remove redundant code in Whatsub (#32)
+* Build with GraalVM (#34)
+* Add `Syncer` to re-sync subtitles (#38)
+* Add `Syncer` and `CanShift` instances for `Srt` (#40)
+* Add `Syncer` and `CanShift` instances for `Smi` (#42)
+* Add CLI option to sync (#44)
+* Write installation scripts (#46)
+* Apply tagless final in core (#51)
+* `Option` to convert `Charset` (#56)
+* Package by function (#58)
+* Better SAMI parser is required (#61)
+* Set `UTF-8` as the default target charset for charset conversion (#63)
+* Bin package using JVM as an alternative to the GraalVM ones (#65)
+* Use colored messages (#69)
+
+## Fixed
+* Incorrect milliseconds in srt playtime in rendered `Srt` (#16)
+* Fix `SmiParser` (#26)
+* Fix GraalVM build on Windows (#47)


### PR DESCRIPTION
# Whatsub v0.1.0
## [0.1.0](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-08-29

## Done
* Add `Smi` and `Srt` data models (#7)
* Add a function to render `Srt` to build an srt subtitle file (#9)
* Add smi file parser (#11)
* Add `Converter` to convert `Smi` to `Srt` (#13)
* Add `SrtParser` (#18)
* `Convert` from `Srt` to `Smi` (#20)
* Add render `Smi` (#22)
* Add error handling to `SmiParser` (#24)
* Add CLI argument models and parsers (#28)
* Add CLI to convert subtitles (#30)
* Remove redundant code in Whatsub (#32)
* Build with GraalVM (#34)
* Add `Syncer` to re-sync subtitles (#38)
* Add `Syncer` and `CanShift` instances for `Srt` (#40)
* Add `Syncer` and `CanShift` instances for `Smi` (#42)
* Add CLI option to sync (#44)
* Write installation scripts (#46)
* Apply tagless final in core (#51)
* `Option` to convert `Charset` (#56)
* Package by function (#58)
* Better SAMI parser is required (#61)
* Set `UTF-8` as the default target charset for charset conversion (#63)
* Bin package using JVM as an alternative to the GraalVM ones (#65)
* Use colored messages (#69)

## Fixed
* Incorrect milliseconds in srt playtime in rendered `Srt` (#16)
* Fix `SmiParser` (#26)
* Fix GraalVM build on Windows (#47)
