### PR TITLE
Fix #82 - Parsing SRT fails when line contains only a number

### DIFF
--- a/core/src/main/scala/whatsub/parse/ParseError.scala
+++ b/core/src/main/scala/whatsub/parse/ParseError.scala
@@ -6,7 +6,7 @@ import cats.parse.Parser as P
 enum ParseError {
   case SmiParseError(lineIndex: Int, lineStr: String, error: P.Error)
   case SmiParseInvalidLineError(lineIndex: Int, lineStr: String, error: String)
-  case SrtParseError(lineIndex: Int, lineStr: String, error: P.Error)
+  case SrtParseError(lineIndex: Int, lineStr: String, additionalInfo: Option[String], error: P.Error)
   case SrtParseInvalidLineError(lineIndex: Int, lineStr: String, error: String)
 }
 object ParseError {
@@ -35,13 +35,14 @@ object ParseError {
            |- error: $error
            |""".stripMargin
 
-      case SrtParseError(lineIndex, lineStr, error) =>
+      case SrtParseError(lineIndex, lineStr, additionalInfo, error) =>
         s"""SrtParseError:
            |- lineIndex: $lineIndex
            |- line:
            |---
            |$lineStr
            |---
+           |additionalInfo: ${additionalInfo.getOrElse("Nothing")}
            |- error: ${error.toString}
            |""".stripMargin
 

--- a/core/src/main/scala/whatsub/parse/SrtComponent.scala
+++ b/core/src/main/scala/whatsub/parse/SrtComponent.scala
@@ -9,6 +9,4 @@ object SrtComponent {
   final case class Index(index: Int)
   final case class Playtimes(start: Playtime, end: Playtime)
   final case class Line(line: String)
-
-  type Component = Index | Playtimes | Line
 }


### PR DESCRIPTION
Fix #82 - Parsing SRT fails when line contains only a number