### PR TITLE
Whatsub v0.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val props =
     final val GitHubUsername = "Kevin-Lee"
     final val RepoName       = "whatsub"
     final val ProjectName    = RepoName
-    final val ProjectVersion = "0.1.1"
+    final val ProjectVersion = "0.1.2"
 
     final val ExecutableScriptName = RepoName
 

--- a/changelogs/0.1.2.md
+++ b/changelogs/0.1.2.md
@@ -1,0 +1,9 @@
+## [0.1.2](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-09-04
+
+## Done
+* Add validation for duplicate `src` and `out` filenames (#79)
+* Create the doc site (#80)
+
+## Fixed
+* Parsing `SRT` fails when line contains only a number (#82)
+* Fix incorrect color in `sync --help` (#86)


### PR DESCRIPTION
# Whatsub v0.1.2
## [0.1.2](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone3) - 2021-09-04

## Done
* Add validation for duplicate `src` and `out` filenames (#79)
* Create the doc site (#80)

## Fixed
* Parsing `SRT` fails when line contains only a number (#82)
* Fix incorrect color in `sync --help` (#86)
