### PR TITLE
Issue #107 - Make 'sub' type optional and use the src file extension to find 'sub' type for 'sync'

### DIFF
--- a/cli/src/main/scala/whatsub/Whatsub.scala
+++ b/cli/src/main/scala/whatsub/Whatsub.scala
@@ -183,17 +183,20 @@ object Whatsub {
       case ConvertArgs(
             None,
             _,
-            from,
+            srcFile,
             _,
           ) =>
         // TODO: Error for missing from type info
-        pureOf(WhatsubError.MissingFrom(from.value).asLeft)
+        pureOf(WhatsubError.MissingSubType("from", srcFile.value).asLeft)
 
-      case SyncArgs(SyncArgs.Sub(SupportedSub.Smi), sync, srcFile, outFile) =>
+      case SyncArgs(Some(SyncArgs.Sub(SupportedSub.Smi)), sync, srcFile, outFile) =>
         resync[F, Smi](SmiParser.parse, sync.value, srcFile.value, outFile)
 
-      case SyncArgs(SyncArgs.Sub(SupportedSub.Srt), sync, srcFile, outFile) =>
+      case SyncArgs(Some(SyncArgs.Sub(SupportedSub.Srt)), sync, srcFile, outFile) =>
         resync[F, Srt](SrtParser.parse, sync.value, srcFile.value, outFile)
+
+      case SyncArgs(None, _, srcFile, _) =>
+        pureOf(WhatsubError.MissingSubType("sub", srcFile.value).asLeft)
 
       case CharsetArgs(CharsetArgs.CharsetTask.ListAll) =>
         charsetListAll[F].map(_.asRight[WhatsubError])

--- a/cli/src/main/scala/whatsub/WhatsubArgs.scala
+++ b/cli/src/main/scala/whatsub/WhatsubArgs.scala
@@ -20,7 +20,7 @@ enum WhatsubArgs derives CanEqual {
     out: Option[ConvertArgs.OutFile],
   )
   case SyncArgs(
-    sub: SyncArgs.Sub,
+    sub: Option[SyncArgs.Sub],
     sync: SyncArgs.Sync,
     src: SyncArgs.SrcFile,
     out: Option[SyncArgs.OutFile],

--- a/cli/src/main/scala/whatsub/WhatsubError.scala
+++ b/cli/src/main/scala/whatsub/WhatsubError.scala
@@ -20,7 +20,7 @@ enum WhatsubError {
 
   case NoConversion(supportedSub: SupportedSub)
 
-  case MissingFrom(srcFile: File)
+  case MissingSubType(forWhat: String, srcFile: File)
 
   case FileWriteFailure(file: File, error: Throwable)
 
@@ -50,8 +50,8 @@ object WhatsubError {
       case NoConversion(supportedSub) =>
         s"""${"No conversion".red}: The subtitle to convert from and to are the same (i.e. ${supportedSub.show})"""
 
-      case MissingFrom(srcFile) =>
-        s"${"Missing from type".red}: There is no from type set nor is the from type info found from the file (${srcFile.toString})."
+      case MissingSubType(what, srcFile) =>
+        s"${s"Missing $what type".red}: There is no $what type set nor is the $what type info found from the file (${srcFile.toString})."
 
       case FileWriteFailure(file: File, error: Throwable) =>
         s"""${"Error".red}: Writing file at ${file.getCanonicalPath} has failed with ${error.getMessage}"""


### PR DESCRIPTION
Issue #107 - Make `sub` type optional and use the src file extension to find `sub` type for `sync`