### PR TITLE
Issue #107 - Make 'to type' optional and use the out file extension to find 'to type' for 'convert'

### DIFF
--- a/cli/src/main/scala/whatsub/WhatsubArgs.scala
+++ b/cli/src/main/scala/whatsub/WhatsubArgs.scala
@@ -15,7 +15,7 @@ import canequal.all.given
 enum WhatsubArgs derives CanEqual {
   case ConvertArgs(
     from: Option[ConvertArgs.From],
-    to: ConvertArgs.To,
+    to: Option[ConvertArgs.To],
     src: ConvertArgs.SrcFile,
     out: Option[ConvertArgs.OutFile],
   )

--- a/core/src/main/scala/whatsub/package.scala
+++ b/core/src/main/scala/whatsub/package.scala
@@ -1,9 +1,13 @@
 
 import cats.effect.kernel.MonadCancel
 
+import java.io.File
+
 /** @author Kevin Lee
   * @since 2021-07-25
   */
 package object whatsub {
   type MCancel[F[_]] = MonadCancel[F, Throwable]
+
+  given fileCanEqual: CanEqual[File, File] = CanEqual.derived
 }


### PR DESCRIPTION
Issue #107 - Make `to` type optional and use the out file extension to find `to` type for `convert`