### PR TITLE
Close #107 - Simplify options - Get rid of subtitle type option - Use extension

### DIFF
--- a/cli/src/main/scala/whatsub/WhatsubArgsParser.scala
+++ b/cli/src/main/scala/whatsub/WhatsubArgsParser.scala
@@ -93,7 +93,10 @@ object WhatsubArgsParser {
 
   def subParse: Parse[Option[SyncArgs.Sub]] = flag[SyncArgs.Sub](
     both('t', "sub-type"),
-    metavar("<sub-type>") |+| description(s"""A type of subtitle. Either ${"smi".blue} or ${"srt".blue}"""),
+    metavar("<sub-type>") |+| description(
+      s"""A type of subtitle. Either ${"smi".blue} or ${"srt".blue}. """ +
+        "Optional. If missing, it gets the sub-type from the extension of the src file.",
+    ),
   ).option
 
   def syncParse: Parse[SyncArgs.Sync] = flag[SyncArgs.Sync](


### PR DESCRIPTION
Close #107 - Simplify options - Get rid of subtitle type option - Use extension
- Update help