### PR TITLE
Updated: The doc site with the JVM version installation info (install-jvm.sh)

### DIFF
--- a/website/docs/whatsub/get-whatsub.mdx
+++ b/website/docs/whatsub/get-whatsub.mdx
@@ -35,6 +35,23 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/Kevin-Lee/whatsub/main/.
 ```
 :::
 
+## macOS and Linux
+
+### JVM Version
+
+If you can't use GraalVM version of whatsub for some reason (i.e. Mac with M1 processor), you can still use the JVM version.
+
+Please make sure that you have Java Runtime Environment (JRE) on your computer.
+
+Please run the following command to install it.
+
+:::tip Recommended
+```shell
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Kevin-Lee/whatsub/main/.scripts/install-jvm.sh)"
+```
+:::
+
+
 
 ### Windows
 #### Install GraalVM Native Image (Recommended)


### PR DESCRIPTION
Updated: The doc site with the JVM version installation info (`install-jvm.sh`)