### PR TITLE
Fix #123 - Parsing SMI results in empty Smi when the style end tag is not the first element of the line

### DIFF
--- a/core/src/main/scala/whatsub/parse/SmiParser.scala
+++ b/core/src/main/scala/whatsub/parse/SmiParser.scala
@@ -104,7 +104,7 @@ object SmiParser {
               parseAll(skipUntil(rest, ParseStatus.BodyStart), title, acc)
             case Some(ParseStatus.TitleStart)   =>
               parseTitle(
-                (line.drop(SmiStr.TitleStart.length), index) +: rest,
+                (line.drop(SmiStr.TitleStart.length + 1), index) +: rest,
               )
                 .rightT[ParseError]
                 .flatMapF {
@@ -119,7 +119,9 @@ object SmiParser {
             case Some(ParseStatus.CommentEnd)   =>
               parseAll(rest, title, acc)
             case Some(ParseStatus.StyleStart)   =>
-              parseAll(skipUntil(rest, ParseStatus.StyleEnd), title, acc)
+              val skippedToStyleEnd = skipUntil(rest, ParseStatus.StyleEnd)
+              if skippedToStyleEnd.isEmpty then parseAll(rest, title, acc)
+              else parseAll(skippedToStyleEnd, title, acc)
             case Some(ParseStatus.StyleEnd)     =>
               parseAll(skipUntil(rest, ParseStatus.HeadEnd), title, acc)
             case Some(ParseStatus.BodyStart)    =>


### PR DESCRIPTION
Fix #123 - Parsing SMI results in empty Smi when the style end tag is not the first element of the line