### PR TITLE
whatsub v1.0.1

### DIFF
--- a/.scripts/install-graal-macos.sh
+++ b/.scripts/install-graal-macos.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.0}
+app_version=${1:-1.0.1}
 app_package_file="${app_name}-macos-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-graal-ubuntu.sh
+++ b/.scripts/install-graal-ubuntu.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.0}
+app_version=${1:-1.0.1}
 app_package_file="${app_name}-ubuntu-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.0}
+app_version=${1:-1.0.1}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_zip_file}"

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val props =
 
     final val ProjectName = RepoName
 
-    final val ProjectVersion = "1.0.0"
+    final val ProjectVersion = "1.0.1"
 
     final val ExecutableScriptName = RepoName
 

--- a/changelogs/1.0.1.md
+++ b/changelogs/1.0.1.md
@@ -1,0 +1,9 @@
+## [1.0.1](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2021-10-14
+
+
+## Done
+* Upgrade `can-equal` (#118)
+* Add installation script for JVM version of `whatsub` (#119)
+
+## Fixed
+* Parsing SMI results in empty Smi when the style end tag is not the first element of the line (#123)


### PR DESCRIPTION
# whatsub v1.0.1
## [1.0.1](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2021-10-14


## Done
* Upgrade `can-equal` (#118)
* Add installation script for JVM version of `whatsub` (#119)

## Fixed
* Parsing SMI results in empty Smi when the style end tag is not the first element of the line (#123)
