### PR TITLE
Update: PR labeler - documentation and publish-docs

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,5 @@
 dependencies: [ 'update/**', 'dependabot/**' ]
+documentation: [ 'docs/**' ]
+publish-docs: [ 'docs/**' ]
 pr: '**'
 release: 'prepare-to-release'


### PR DESCRIPTION
Update: PR labeler - `documentation` and `publish-docs`