### PR TITLE
whatsub v1.0.2

### DIFF
--- a/changelogs/1.0.2.md
+++ b/changelogs/1.0.2.md
@@ -1,0 +1,12 @@
+## [1.0.2](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2022-03-05
+
+
+## Fixed
+* SMI `<SYNC>` having `End` attribute causes a parse failure (#155)
+* `SmiParser` - Having comment inside `<BODY>` causes a parse error (#159)
+
+## Done
+* Upgrade Scala to `3.1.0` (#128)
+* Upgrade Effectie to `1.16.0` (#130)
+* Upgrade Effectie to `2.0.0-SNAPSHOT` (#157)
+* Use `extension` methods with type classes (#132)


### PR DESCRIPTION
# whatsub v1.0.2
## [1.0.2](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2022-03-05


## Fixed
* SMI `<SYNC>` having `End` attribute causes a parse failure (#155)
* `SmiParser` - Having comment inside `<BODY>` causes a parse error (#159)

## Done
* Upgrade Scala to `3.1.0` (#128)
* Upgrade Effectie to `1.16.0` (#130)
* Upgrade Effectie to `2.0.0-SNAPSHOT` (#157)
* Use `extension` methods with type classes (#132)
