### PR TITLE
Upgrade: sbt and plugins

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.4")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 addSbtPlugin("org.scalameta"  % "sbt-native-image"    % "0.3.0")
-addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"       % "0.10.0")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"       % "0.11.0")
 
 addSbtPlugin("io.kevinlee"   % "sbt-docusaur" % "0.8.1")
 
-val sbtDevOopsVersion = "2.14.0"
+val sbtDevOopsVersion = "2.15.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
Upgrade: sbt and plugins
- sbt 1.6.1 => 1.6.2
- sbt-native-packager 1.9.4 => 1.9.9
- sbt-buildinfo 0.10.0 => 0.11.0
- sbt-devoops 2.14.0 => 2.15.0