### PR TITLE
whatsub v1.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val props =
 
     final val ProjectName = RepoName
 
-    final val ProjectVersion = "1.0.2"
+    final val ProjectVersion = "1.0.3"
 
     final val ExecutableScriptName = RepoName
 

--- a/changelogs/1.0.3.md
+++ b/changelogs/1.0.3.md
@@ -1,0 +1,8 @@
+## [1.0.3](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2022-03-05
+
+
+## Fixed
+* A comment between line start and end makes `SmiParser` skip the line (#167)
+
+## Done
+* Add golden test for `Convert[F, A, B]` (#169)


### PR DESCRIPTION
# whatsub v1.0.3
## [1.0.3](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2022-03-05


## Fixed
* A comment between line start and end makes `SmiParser` skip the line (#167)

## Done
* Add golden test for `Convert[F, A, B]` (#169)
