### PR TITLE
Close #187 - Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,21 +97,21 @@ lazy val props =
 
     final val SonatypeCredentialHost = "s01.oss.sonatype.org"
 
-    final val HedgehogVersion = "0.8.0"
+    final val HedgehogVersion = "0.9.0"
 
     final val CatsVersion        = "2.7.0"
-    final val CatsEffect3Version = "3.3.6"
+    final val CatsEffect3Version = "3.3.12"
 
-    final val CatsParseVersion = "0.3.4"
+    final val CatsParseVersion = "0.3.7"
 
-    final val EffectieCatsEffect3Version = "2.0.0-SNAPSHOT"
+    final val EffectieCatsEffect3Version = "2.0.0-beta1"
 
     final val pirateVersion = "deec3408b08a751de9b2df2d17fc1ab7b8daeaaf"
     final val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$pirateVersion")
 
     final val IncludeTest: String = "compile->compile;test->test"
 
-    final val ExtrasVersion = "0.4.0"
+    final val ExtrasVersion = "0.15.0"
 
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,9 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.0.4")
 
 addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.11.0")
 
-val sbtDevOopsVersion = "2.20.0"
+val sbtDevOopsVersion = "2.21.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
+
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)


### PR DESCRIPTION
Close #187 - Upgrade libraries
* `hedgehog` `0.8.0` => `0.9.0`
* `cats-effect` `3.3.6` => `3.3.12`
* `cats-parse` `0.3.4` => `0.3.7`
* `effectie-cats-effect3` `2.0.0-SNAPSHOT` => `2.0.0-beta1`
* `extras-cats` and `extras-scala-io` `0.4.0` => `0.15.0`
* `sbt-devoops` `2.20.0` => `2.21.0`