### PR TITLE
Close #197 - Make `FileF.writeFile` more reusable with a function using `Writer`

### DIFF
--- a/cli/src/main/scala/whatsub/WhatsubError.scala
+++ b/cli/src/main/scala/whatsub/WhatsubError.scala
@@ -4,6 +4,7 @@ import cats.Show
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
+import whatsub.FileF
 import whatsub.WhatsubArgsParser.ArgParseError
 import whatsub.charset.{CharsetConvertError, ConvertCharset}
 import whatsub.convert.ConversionError
@@ -30,6 +31,8 @@ enum WhatsubError {
   case CharsetConversion(charsetConvertError: CharsetConvertError)
 
   case IdenticalSrcAndOut(src: File, out: Option[File])
+
+  case FileF(err: whatsub.FileF.FileError)
 }
 
 object WhatsubError {
@@ -39,25 +42,26 @@ object WhatsubError {
   extension (whatsubError: WhatsubError) {
     def render: String = whatsubError match {
       case WhatsubError.ConversionFailure(conversionError) =>
-        s"""${"Conversion Failed".red}:
-           |${conversionError.render}
+        s""">> ${"Conversion Failed".red}:
+           |>> ${conversionError.render}
            |""".stripMargin
 
       case WhatsubError.ParseFailure(parseError) =>
-        s"""${"Parsing sub failed".red}:
-           |${parseError.render}
+        s""">> ${"Parsing sub failed".red}:
+           |>> ${parseError.render}
            |""".stripMargin
 
       case WhatsubError.NoConversion(supportedSub) =>
-        s"""${"No conversion".red}: The subtitle to convert from and to are the same (i.e. ${supportedSub.show})"""
+        s""">> ${"No conversion".red}: The subtitle to convert from and to are the same (i.e. ${supportedSub.show})
+           |""".stripMargin
 
       case WhatsubError.MissingSubTypes(typeToFile) =>
         typeToFile
           .map {
             case (what, Some(file)) =>
-              s"${s"Missing $what type".red}: There is no $what type set nor is the $what type info found from the file (${file.toString})."
+              s">> ${s"Missing $what type".red}: There is no $what type set nor is the $what type info found from the file (${file.toString}).\n"
             case (what, None) =>
-              s"${s"Missing $what type".red}: There is no $what type set nor is there a file path given for the $what type."
+              s">> ${s"Missing $what type".red}: There is no $what type set nor is there a file path given for the $what type.\n"
           }
           .toList
           .mkString("\n")
@@ -66,33 +70,37 @@ object WhatsubError {
         s"""${"Error".red}: Writing file at ${file.getCanonicalPath} has failed with ${error.getMessage}"""
 
       case WhatsubError.ArgParse(error) =>
-        s"""${"CLI arguments error".red}:
-           |${error.show}
+        s""">> ${"CLI arguments error".red}:
+           |>> ${error.show}
            |""".stripMargin
 
       case WhatsubError.CharsetConversion(
             CharsetConvertError.Conversion(from, to, input, error),
           ) =>
-        s"""${"Error when converting charset".red}
-           | From: $from
-           |   To: $to
-           |input: $input
-           |error: ${error.getMessage}
+        s""">> ${"Error when converting charset".red}
+           |>>  From: $from
+           |>>    To: $to
+           |>> input: $input
+           |>> error: ${error.getMessage}
            |""".stripMargin
 
       case WhatsubError.CharsetConversion(
             CharsetConvertError.Consumption(converted, error),
           ) =>
-        s"""${"Error when consuming converted subtitle content".red}
-           |converted: $converted
-           |    error: ${error.getMessage}
+        s""">> ${"Error when consuming converted subtitle content".red}
+           |>> converted: $converted
+           |>>     error: ${error.getMessage}
            |""".stripMargin
 
       case WhatsubError.IdenticalSrcAndOut(src, out) =>
-        s"""${"Invalid out filename or path".red}
-           |The src file path and the out file path are the same. The out one should be different.
-           |src: ${src.getCanonicalPath}
-           |out: ${out.fold("")(_.getCanonicalPath)}
+        s""">> ${"Invalid out filename or path".red}
+           |>> The src file path and the out file path are the same. The out one should be different.
+           |>> src: ${src.getCanonicalPath}
+           |>> out: ${out.fold("")(_.getCanonicalPath)}
+           |""".stripMargin
+
+      case WhatsubError.FileF(err) =>
+        s""">> [${"Error".red}] ${err.render.split("\n").mkString("\n>> ")}
            |""".stripMargin
     }
   }

--- a/core/src/main/scala/whatsub/charset/ConvertCharset.scala
+++ b/core/src/main/scala/whatsub/charset/ConvertCharset.scala
@@ -31,7 +31,8 @@ object ConvertCharset {
           converted <- effectOf(
                          new String(
                            input
-                             .replaceAll(EmptyCharRegEx, "").nn
+                             .replaceAll(EmptyCharRegEx, "")
+                             .nn
                              .getBytes(from.javaCharset),
                            to.javaCharset,
                          ),
@@ -59,7 +60,8 @@ object ConvertCharset {
                   converted <- effectOf(
                                  new String(
                                    line
-                                     .replaceAll(EmptyCharRegEx, "").nn
+                                     .replaceAll(EmptyCharRegEx, "")
+                                     .nn
                                      .getBytes(Charset.Utf8.value),
                                    to.javaCharset,
                                  ),


### PR DESCRIPTION
Close #197 - Make `FileF.writeFile` more reusable with a function using `Writer`