### PR TITLE
whatsub v1.1.0

### DIFF
--- a/.scripts/install-graal-macos.sh
+++ b/.scripts/install-graal-macos.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.4}
+app_version=${1:-1.1.0}
 app_package_file="${app_name}-macos-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-graal-ubuntu.sh
+++ b/.scripts/install-graal-ubuntu.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.4}
+app_version=${1:-1.1.0}
 app_package_file="${app_name}-ubuntu-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.0.4}
+app_version=${1:-1.1.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_zip_file}"

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val props =
 
     final val ProjectName = RepoName
 
-    final val ProjectVersion = "1.0.4"
+    final val ProjectVersion = "1.1.0"
 
     final val ExecutableScriptName = RepoName
 

--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,19 @@
+## [1.1.0](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2022-06-18
+
+
+## Done
+* Add success message for charset conversion (#192)
+* Highlight the result message and file path with color (#195)
+* Make `FileF.writeFile` more reusable with a function using `Writer` (#197)
+* Upgrade Java to `17` and GraalVM native image version `22.1.0` (#185)
+* Set up `WartRemover` for Scala 3 (#180)
+* Upgrade libraries (#187)
+  * `hedgehog` `0.8.0` => `0.9.0`
+  * `cats-effect` `3.3.6` => `3.3.12`
+  * `cats-parse` `0.3.4` => `0.3.7`
+  * `effectie-cats-effect3` `2.0.0-SNAPSHOT` => `2.0.0-beta1`
+  * `extras-cats` and `extras-scala-io` `0.4.0` => `0.15.0`
+  * `sbt-devoops` `2.20.0` => `2.21.0`
+* Upgrade `pirate` (#189) - `deec3408b08a751de9b2df2d17fc1ab7b8daeaaf` => `18dfbbca014ba2312a640cf558ab6eca19c47eb8`
+* Upgrade `cats` `2.7.0` => `2.8.0` (#201)
+* Add Scalafix and Scalafmt (#199)


### PR DESCRIPTION
# whatsub v1.1.0
## [1.1.0](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2022-06-18


## Done
* Add success message for charset conversion (#192)
* Highlight the result message and file path with color (#195)
* Make `FileF.writeFile` more reusable with a function using `Writer` (#197)
* Upgrade Java to `17` and GraalVM native image version `22.1.0` (#185)
* Set up `WartRemover` for Scala 3 (#180)
* Upgrade libraries (#187)
  * `hedgehog` `0.8.0` => `0.9.0`
  * `cats-effect` `3.3.6` => `3.3.12`
  * `cats-parse` `0.3.4` => `0.3.7`
  * `effectie-cats-effect3` `2.0.0-SNAPSHOT` => `2.0.0-beta1`
  * `extras-cats` and `extras-scala-io` `0.4.0` => `0.15.0`
  * `sbt-devoops` `2.20.0` => `2.21.0`
* Upgrade `pirate` (#189) - `deec3408b08a751de9b2df2d17fc1ab7b8daeaaf` => `18dfbbca014ba2312a640cf558ab6eca19c47eb8`
* Upgrade `cats` `2.7.0` => `2.8.0` (#201)
* Add Scalafix and Scalafmt (#199)