### PR TITLE
Closea #226 - Bump Scala and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val cli = module("cli")
 
 lazy val props =
   new {
-    final val ScalaVersion = "3.2.0"
+    final val ScalaVersion = "3.2.1"
     final val Org          = "io.kevinlee"
 
     private val gitHubRepo = findRepoOrgAndName
@@ -98,19 +98,19 @@ lazy val props =
 
     final val HedgehogVersion = "0.9.0"
 
-    final val CatsVersion        = "2.8.0"
-    final val CatsEffect3Version = "3.3.14"
+    final val CatsVersion        = "2.9.0"
+    final val CatsEffect3Version = "3.4.1"
 
     final val CatsParseVersion = "0.3.8"
 
-    final val EffectieCatsEffect3Version = "2.0.0-beta2"
+    final val EffectieCatsEffect3Version = "2.0.0-beta3"
 
-    final val pirateVersion = "18dfbbca014ba2312a640cf558ab6eca19c47eb8"
+    final val pirateVersion = "7797fb3884bdfdda7751d8f75accf622b30a53ed"
     final val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$pirateVersion")
 
     final val IncludeTest: String = "compile->compile;test->test"
 
-    final val ExtrasVersion = "0.19.0"
+    final val ExtrasVersion = "0.25.0"
 
   }
 
@@ -134,7 +134,7 @@ lazy val libs =
     lazy val extrasCats    = "io.kevinlee" %% "extras-cats"     % props.ExtrasVersion
     lazy val extrasScalaIo = "io.kevinlee" %% "extras-scala-io" % props.ExtrasVersion
 
-    lazy val extrasHedgehogCatsEffect3 = "io.kevinlee" %% "extras-hedgehog-cats-effect3" % props.ExtrasVersion % Test
+    lazy val extrasHedgehogCatsEffect3 = "io.kevinlee" %% "extras-hedgehog-ce3" % props.ExtrasVersion % Test
 
   }
 

--- a/modules/whatsub-cli/src/main/scala/whatsub/FileF.scala
+++ b/modules/whatsub-cli/src/main/scala/whatsub/FileF.scala
@@ -6,6 +6,7 @@ import cats.effect.*
 import cats.effect.kernel.MonadCancel
 import cats.syntax.all.*
 import effectie.core.*
+import effectie.instances.console.*
 import effectie.syntax.all.{*, given}
 import extras.cats.syntax.all.*
 import extras.scala.io.syntax.color.*

--- a/modules/whatsub-cli/src/main/scala/whatsub/MainIo.scala
+++ b/modules/whatsub-cli/src/main/scala/whatsub/MainIo.scala
@@ -4,7 +4,8 @@ import cats.Show
 import cats.effect.*
 import cats.syntax.all.*
 import effectie.syntax.all.{*, given}
-import effectie.ce3.fx.given
+import effectie.instances.ce3.fx.given
+import effectie.instances.console.*
 import pirate.{Command, Prefs, Runners, ExitCode as PirateExitCode}
 import piratex.{Help, Metavar}
 import whatsub.WhatsubArgsParser.{ArgParseError, ArgParseFailureResult, JustMessageOrHelp}

--- a/modules/whatsub-cli/src/main/scala/whatsub/Whatsub.scala
+++ b/modules/whatsub-cli/src/main/scala/whatsub/Whatsub.scala
@@ -7,6 +7,7 @@ import cats.effect.{Resource, Sync}
 import cats.syntax.all.*
 import cats.{Monad, Monoid}
 import effectie.core.*
+import effectie.instances.console.*
 import effectie.syntax.all.{*, given}
 import extras.cats.syntax.all.*
 import extras.scala.io.syntax.color.*

--- a/modules/whatsub-cli/src/main/scala/whatsub/WhatsubApp.scala
+++ b/modules/whatsub-cli/src/main/scala/whatsub/WhatsubApp.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import pirate.{Command, DefaultPrefs, Prefs}
 import piratex.{Help, Metavar}
-import effectie.ce3.fx.given
+import effectie.instances.ce3.fx.given
 
 /** @author Kevin Lee
   * @since 2021-06-30

--- a/modules/whatsub-core/src/test/scala/whatsub/convert/ConvertSpec.scala
+++ b/modules/whatsub-core/src/test/scala/whatsub/convert/ConvertSpec.scala
@@ -3,11 +3,11 @@ package whatsub.convert
 import cats.*
 import cats.effect.IO
 import cats.syntax.all.*
-import effectie.ce3.fx.given
+import effectie.instances.ce3.fx.given
 import effectie.core.Fx
 import effectie.syntax.all.*
 import extras.cats.syntax.all.*
-import extras.hedgehog.cats.effect.CatsEffectRunner
+import extras.hedgehog.ce3.CatsEffectRunner
 import hedgehog.*
 import hedgehog.runner.*
 import whatsub.convert.Convert
@@ -19,7 +19,7 @@ import scala.reflect.*
 /** @author Kevin Lee
   * @since 2022-03-05
   */
-object ConvertSpec extends Properties {
+object ConvertSpec extends Properties with CatsEffectRunner {
   override def tests: List[Prop] = List(
     goldenTestConvert[Smi, Srt]("golden/test-src.smi", "golden/test-out.srt", SmiParser.parse[IO]),
     goldenTestConvert[Srt, Smi]("golden/test-src.srt", "golden/test-out.smi", SrtParser.parse[IO]),
@@ -62,9 +62,8 @@ object ConvertSpec extends Properties {
     val result = testGolden[IO, A, B](srcFile, outFile, aParser)
 
     example(
-      name, {
-        import CatsEffectRunner.*
-        given ticker: Ticker = Ticker.withNewTestContext()
+      name,
+      withIO { implicit ticker =>
         result.completeThen(identity)
       },
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := sbt.Level.Warn
 addSbtPlugin("com.github.sbt"  % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("org.scalameta"   % "sbt-native-image"    % "0.3.0")
 addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo"       % "0.11.0")
-addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.0.6")
+addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.0.7")
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"        % "2.4.6")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"        % "0.10.3")
 


### PR DESCRIPTION
Closea #226 - Bump Scala and libraries
* Scala 3.2.0 => 3.2.1
* Cats 2.8.0 => 2.9.0
* Cats Effect 3.3.14 => 3.4.1
* Effectie 2.0.0-beta2 => 2.0.0-beta3
* Extras 0.19.0 => 0.25.0
* Pirate 18dfbbca014ba2312a640cf558ab6eca19c47eb8 => 7797fb3884bdfdda7751d8f75accf622b30a53ed