### PR TITLE
whatsub v1.2.1

### DIFF
--- a/.scripts/install-graal-macos.sh
+++ b/.scripts/install-graal-macos.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.2.0}
+app_version=${1:-1.2.1}
 app_package_file="${app_name}-macos-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-graal-ubuntu.sh
+++ b/.scripts/install-graal-ubuntu.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.2.0}
+app_version=${1:-1.2.1}
 app_package_file="${app_name}-ubuntu-latest"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_package_file}"
 

--- a/.scripts/install-jvm.sh
+++ b/.scripts/install-jvm.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=whatsub
 app_name=whatsub-cli
-app_version=${1:-1.2.0}
+app_version=${1:-1.2.1}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/whatsub/releases/download/v${app_version}/${app_zip_file}"

--- a/changelogs/1.2.1.md
+++ b/changelogs/1.2.1.md
@@ -1,0 +1,13 @@
+## [1.2.1](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2023-05-16
+
+## Bug Fix
+* Parsing SAMI file fails when there's no `<TITLE>` tag (#252)
+
+
+## Internal Housekeeping
+* Upgrade Scala and libraries
+  * Scala to `3.2.2`
+  * cats-effect to `3.4.8`
+  * effectie to `2.0.0-beta9`
+  * extras to `0.38.0`
+* sbt-wartremover to `3.1.0`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "1.2.1"


### PR DESCRIPTION
# whatsub v1.2.1
## [1.2.1](https://github.com/Kevin-Lee/whatsub/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12) - 2023-05-16

## Bug Fix
* Parsing SAMI file fails when there's no `<TITLE>` tag (#252)


## Internal Housekeeping
* Upgrade Scala and libraries
  * Scala to `3.2.2`
  * cats-effect to `3.4.8`
  * effectie to `2.0.0-beta9`
  * extras to `0.38.0`
* sbt-wartremover to `3.1.0`
