### PR TITLE
Bump sbt plugins and scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.1
+version = 3.7.4
 runner.dialect = scala3
 
 //align.preset=more

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-native-packager" % "1.9.11")
+addSbtPlugin("com.github.sbt"  % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("org.scalameta"   % "sbt-native-image"    % "0.3.0")
 addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo"       % "0.11.0")
-addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.1.0")
-addSbtPlugin("org.scalameta"   % "sbt-scalafmt"        % "2.4.6")
-addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"        % "0.10.3")
+addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.1.3")
+addSbtPlugin("org.scalameta"   % "sbt-scalafmt"        % "2.5.0")
+addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"        % "0.11.0")
 
 addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.13.0")
 


### PR DESCRIPTION
Bump sbt plugins and scalafmt
- sbt-native-packager to 1.9.16
- sbt-wartremover to 3.1.3
- sbt-scalafmt to 2.5.0
- sbt-scalafix to 0.11.0
- scalafmt to 3.7.4