### PR TITLE
Fix GitHub Actions build for Windows - Resize JVM memory setup

### DIFF
--- a/.github/workflows/build-graal.yml
+++ b/.github/workflows/build-graal.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 env:
-  GH_SBT_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=1G -Xmx6G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
-  GH_JVM_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=1G -Xmx6G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_SBT_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=1G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=1G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
   CLI_SCALA_VERSION: "3.3.0"
   CLI_SCALA_BINARY_VERSION: "3"
   GRAALVM_JAVA_VERSION: "17"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   GH_JAVA_VERSION: "17"
-  GH_SBT_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=1G -Xmx6G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
-  GH_JVM_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=1G -Xmx6G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_SBT_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=1G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=1G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
   CLI_SCALA_VERSION: "3.3.0"
   CLI_SCALA_BINARY_VERSION: "3"
   GRAALVM_JAVA_VERSION: "17"


### PR DESCRIPTION
Fix GitHub Actions build for Windows - Resize JVM memory setup
* Based on the following reference:
  https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources