### PR TITLE
Update website Docusaurus and TypeScript

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,20 +15,22 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.7.0",
-    "@docusaurus/preset-classic": "3.7.0",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/faster": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-lunr-search": "^3.6.0",
+    "docusaurus-lunr-search": "^3.6.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.7.0",
-    "@docusaurus/tsconfig": "3.7.0",
-    "@docusaurus/types": "3.7.0",
-    "typescript": "~5.6.2"
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
+    "@types/react": "^19.0.0",
+    "typescript": "~6.0.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Update website Docusaurus and TypeScript

- `docusaurus`: `3.7.0` => `3.10.1`
- `docusaurus-lunr-search`: `3.6.0` => `3.6.1`
- `typescript`: `5.6.2` => `6.0.2`
- Add `@docusaurus/faster`: `3.10.1`
- Add `@types/react`: `19.0.0`